### PR TITLE
Protocol fix: Take n into consideration when reading command

### DIFF
--- a/verifier/main.c
+++ b/verifier/main.c
@@ -79,9 +79,11 @@ static int read_command(struct frame_header *hdr, uint8_t *cmd)
 				return -1;
 			}
 
-			// Read as much as is available of what we expect from
-			// the frame.
-			available = available > hdr->len ? hdr->len : available;
+			// Read as much as is available from what
+			// remains
+			if (available > hdr->len - n) {
+				available = hdr->len - n;
+			}
 
 			debug_puts("verifier: reading ");
 			debug_putinthex(available);


### PR DESCRIPTION
## Description

When considering how many bytes is available of the command, consider how many bytes (n) we already have read.

## Type of change

- [x] Bugfix (non breaking change which resolve an issue)


## Submission checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [ ] My changes are well written and CI is passing
- [ ] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
