### PR TITLE
sign-tool: Add option to export binary pub key from Signify pub key

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,11 @@ corresponding to this public key you can use for testing:
 
 NOTE WELL: For real use signing of device apps [the tkey-sign
 tool](https://github.com/tillitis/tkey-sign-cli) with BLAKE2s support
-will most likely be used instead of `sign-tool`.
+will most likely be used instead of `sign-tool`. Typically:
+
+```
+tkey-sign -S -a b2s --uss -m fido2.bin  -p pubkey 
+```
 
 #### install-pubkey
 
@@ -194,13 +198,13 @@ this tool. Then this is a typical series of commands:
 
 ```
 # Get the public key from the TKey
-tkey-sign -G -p newkey.pub
+tkey-sign -G --uss -p newkey.pub
 
 # Convert it to binary form to be able to sign it as a message.
 ./sign-tool -P newkey.bin -p newkey.pub
 
 # Sign the binary key with old private key
-tkey-sign -S -a b2s -m newkey.bin -p oldkey.pub
+tkey-sign -S --uss -a b2s -m newkey.bin -p oldkey.pub
 
 # Install the new public key on your TKey
 ./tkey-mgt -cmd install-pubkey -pub newkey.pub -sig newkey.bin.sig

--- a/README.md
+++ b/README.md
@@ -188,6 +188,24 @@ vendor private key. Typical series of commands:
 
 Remember to use `-no-expect-close` if you're running against qemu.
 
+For *production* you should be using a TKey and
+[`tkey-sign`](https://github.com/tillitis/tkey-sign-cli) instead of
+this tool. Then this is a typical series of commands:
+
+```
+# Get the public key from the TKey
+tkey-sign -G -p newkey.pub
+
+# Convert it to binary form to be able to sign it as a message.
+./sign-tool -P newkey.bin -p newkey.pub
+
+# Sign the binary key with old private key
+tkey-sign -S -a b2s -m newkey.bin -p oldkey.pub
+
+# Install the new public key on your TKey
+./tkey-mgt -cmd install-pubkey -pub newkey.pub -sig newkey.bin.sig
+```
+
 ## Chained Reset
 
 ### Example: Verified boot from client

--- a/cmd/sign-tool/sign-tool.go
+++ b/cmd/sign-tool/sign-tool.go
@@ -23,6 +23,8 @@ func usage() {
 
 	_, _ = fmt.Fprintf(flag.CommandLine.Output(), "Write pubkey (in binary form with -P) generated from seckey to FILE.\n")
 	_, _ = fmt.Fprintf(flag.CommandLine.Output(), "%s -p|P FILE -s seckey\n\n", os.Args[0])
+	_, _ = fmt.Fprintf(flag.CommandLine.Output(), "Write pubkey in binary form from Signify format to FILE.\n")
+	_, _ = fmt.Fprintf(flag.CommandLine.Output(), "%s -P FILE -p key.pub\n\n", os.Args[0])
 
 	flag.PrintDefaults()
 }
@@ -42,8 +44,8 @@ type pubKey struct {
 func main() {
 	messagePath := flag.String("m", "", "File containing message to sign")
 	sigPath := flag.String("o", "", "File to write signature to. Default: <message-file>.sig")
-	pubkeyPath := flag.String("p", "", "File to write pubkey to")
-	binPubkeyPath := flag.String("P", "", "File to write pubkey to")
+	pubkeyPath := flag.String("p", "", "Public key file to read from or write to")
+	binPubkeyPath := flag.String("P", "", "File to write binary pubkey to")
 	seedPath := flag.String("s", "", "File containing private key seed in hex")
 	flag.Usage = usage
 
@@ -56,35 +58,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	if *seedPath == "" {
-		flag.Usage()
-		os.Exit(1)
-	}
-
-	seedHex, err := os.ReadFile(*seedPath)
-	if err != nil {
-		fmt.Printf("couldn't read file: %v\n", err)
-		os.Exit(1)
-	}
-	if len(seedHex) < 64 {
-		fmt.Printf("Expected seed length: 64, got %d\n", len(seedHex))
-		os.Exit(1)
-	}
-
-	var seed [32]byte
-	seedLen, err := hex.Decode(seed[:], seedHex[:64])
-	if err != nil {
-		fmt.Printf("Invalid seed: %s\n", seed)
-		os.Exit(1)
-	}
-	if seedLen != 32 {
-		fmt.Printf("Expected seed length: 32, got %d\n", seedLen)
-		os.Exit(1)
-	}
-
-	privateKey := ed25519.NewKeyFromSeed(seed[:])
-
 	if *messagePath != "" {
+		privateKey, err := readPrivate(*seedPath)
+		if err != nil {
+			fmt.Printf("reading private key: %v", err)
+		}
+
 		message, err := os.ReadFile(*messagePath)
 		if err != nil {
 			fmt.Printf("couldn't read file: %v\n", err)
@@ -113,7 +92,43 @@ func main() {
 			fmt.Printf("Couldn't store signature: %v", err)
 			os.Exit(1)
 		}
+	} else if *binPubkeyPath != "" {
+		// Write only the public key part as a binary file
+
+		if *seedPath == "" {
+			// Export binary form of pubkey from Signify pubkey
+			pub, err := sigfile.ReadKey(*pubkeyPath)
+			if err != nil {
+				fmt.Printf("Couldn't read pubkey: %v\n", err)
+				os.Exit(1)
+			}
+
+			err = sigfile.WriteBinary(*binPubkeyPath, pub.Key, true)
+			if err != nil {
+				fmt.Printf("Couldn't store pubkey: %v\n", err)
+				os.Exit(1)
+			}
+		} else {
+			// Export binary form derived from private key
+			privateKey, err := readPrivate(*seedPath)
+			if err != nil {
+				fmt.Printf("reading private key: %v\n", err)
+				os.Exit(1)
+			}
+
+			err = sigfile.WriteBinary(*binPubkeyPath, privateKey.Public().(ed25519.PublicKey), true)
+			if err != nil {
+				fmt.Printf("Couldn't store pubkey: %v\n", err)
+				os.Exit(1)
+			}
+		}
 	} else if *pubkeyPath != "" {
+		privateKey, err := readPrivate(*seedPath)
+		if err != nil {
+			fmt.Printf("reading private key: %v\n", err)
+			os.Exit(1)
+		}
+
 		pub := pubKey{
 			Alg:    [2]byte{'E', 'b'},
 			KeyNum: [8]byte{1, 7},
@@ -125,13 +140,26 @@ func main() {
 			fmt.Printf("Couldn't store pubkey: %v\n", err)
 			os.Exit(1)
 		}
-	} else if *binPubkeyPath != "" {
-		// Write only the public key part as a binary file
-
-		err = sigfile.WriteBinary(*binPubkeyPath, privateKey.Public().(ed25519.PublicKey), true)
-		if err != nil {
-			fmt.Printf("Couldn't store pubkey: %v\n", err)
-			os.Exit(1)
-		}
 	}
+}
+
+func readPrivate(seedPath string) (ed25519.PrivateKey, error) {
+	seedHex, err := os.ReadFile(seedPath)
+	if err != nil {
+		return nil, fmt.Errorf("%w", err)
+	}
+	if len(seedHex) < 64 {
+		return nil, fmt.Errorf("expected hex seed length: 64, got %d", len(seedHex))
+	}
+
+	var seed [32]byte
+	seedLen, err := hex.Decode(seed[:], seedHex[:64])
+	if err != nil {
+		return nil, fmt.Errorf("invalid seed: %s", seed)
+	}
+	if seedLen != 32 {
+		return nil, fmt.Errorf("expected seed length: 32, got %d", seedLen)
+	}
+
+	return ed25519.NewKeyFromSeed(seed[:]), nil
 }

--- a/cmd/tkey-mgt/tkey-mgt.go
+++ b/cmd/tkey-mgt/tkey-mgt.go
@@ -245,7 +245,7 @@ func reconnect(tk *tkeyclient.TillitisKey) {
 func usage() {
 	_, _ = fmt.Fprintf(flag.CommandLine.Output(), "%s -cmd boot -app path -sig path -pub path-to-pubkey\n", os.Args[0])
 	_, _ = fmt.Fprintf(flag.CommandLine.Output(), "%s -cmd install -app path -sig path\n", os.Args[0])
-	_, _ = fmt.Fprintf(flag.CommandLine.Output(), "%s -cmd install-pubkey -pub path\n", os.Args[0])
+	_, _ = fmt.Fprintf(flag.CommandLine.Output(), "%s -cmd install-pubkey -pub path -sig path\n", os.Args[0])
 	_, _ = fmt.Fprintf(flag.CommandLine.Output(), "%s -cmd erase-areas\n", os.Args[0])
 	flag.PrintDefaults()
 }


### PR DESCRIPTION
## Description

In order to be able to sign a a vendor pubkey and install it with tkey-mgt -cmd install-pubkey we need to have the binary form of the new key.

If we're using a TKey for signing, we get the pubkey in Signify form from tkey-sign -G. Let's make it possible to convert to binary form with:

sign-tool -P newkey.bin -p newkey.pub


## Type of change

Please tick any that are relevant to this PR and remove any that aren't.

- [ ] Bugfix (non breaking change which resolve an issue)
- [x] Feature (non breaking change which adds functionality)
- [ ] Breaking Change (a change which would cause existing functionality to not work as expected)
- [x] Documentation (a change to documentation)

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [ ] I have tested and verified my changes on target
- [x] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [ ] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [x] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
