### PR TITLE
tkey-mgt: add missing -sig flag to install-pubkey usage

### DIFF
--- a/cmd/tkey-mgt/tkey-mgt.go
+++ b/cmd/tkey-mgt/tkey-mgt.go
@@ -245,7 +245,7 @@ func reconnect(tk *tkeyclient.TillitisKey) {
 func usage() {
 	_, _ = fmt.Fprintf(flag.CommandLine.Output(), "%s -cmd boot -app path -sig path -pub path-to-pubkey\n", os.Args[0])
 	_, _ = fmt.Fprintf(flag.CommandLine.Output(), "%s -cmd install -app path -sig path\n", os.Args[0])
-	_, _ = fmt.Fprintf(flag.CommandLine.Output(), "%s -cmd install-pubkey -pub path\n", os.Args[0])
+	_, _ = fmt.Fprintf(flag.CommandLine.Output(), "%s -cmd install-pubkey -pub path -sig path\n", os.Args[0])
 	_, _ = fmt.Fprintf(flag.CommandLine.Output(), "%s -cmd erase-areas\n", os.Args[0])
 	flag.PrintDefaults()
 }


### PR DESCRIPTION
## Description
Found nits in the usage printout

## Type of change
- [x] bugfix

## Submission checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my changes
- [x] I have tested and verified my changes on target
- [x] My changes are well written and CI is passing
- [x] I have squashed my work to relevant commits and rebased on main for linear history
- [x] I have added a "Co-authored-by: x" if several people contributed, either pair programming or by squashing commits from different authors.
- [ ] I have updated the documentation where relevant (readme, dev.tillitis.se etc.)
- [ ] QEMU is updated to reflect changes
